### PR TITLE
Shorten method receiver name

### DIFF
--- a/layouttemplatemanager.go
+++ b/layouttemplatemanager.go
@@ -16,17 +16,17 @@ func getLayoutTemplateManager(templateManager *TemplateManager, layoutTemplateNa
 }
 
 // GetTemplate gets a template from the templateFolder based on the templateName
-func (layoutTemplateManager *LayoutTemplateManager) GetTemplate(templateName string) (tpl *template.Template, err error) {
-	funcs := layoutTemplateManager.funcs
+func (layout *LayoutTemplateManager) GetTemplate(templateName string) (tpl *template.Template, err error) {
+	funcs := layout.funcs
 	funcs["pagoda_layout_placeholder"] = func(data interface{}) string {
-		return layoutTemplateManager.execSubTemplate(templateName, data)
+		return layout.execSubTemplate(templateName, data)
 	}
-	return layoutTemplateManager.getTemplate(layoutTemplateManager.layoutTemplateName, funcs)
+	return layout.getTemplate(layout.layoutTemplateName, funcs)
 }
 
 // Execute a template named templateName
-func (layoutTemplateManager *LayoutTemplateManager) Execute(templateName string, writer io.Writer, data interface{}) (err error) {
-	tpl, err := layoutTemplateManager.GetTemplate(templateName)
+func (layout *LayoutTemplateManager) Execute(templateName string, writer io.Writer, data interface{}) (err error) {
+	tpl, err := layout.GetTemplate(templateName)
 
 	if err == nil {
 		err = tpl.Execute(writer, data)


### PR DESCRIPTION
This shortens method receiver name for LayoutTemplateManager to layout. The short
version makes the code more readable and easy to use.
